### PR TITLE
use `is` for comparison with `None`

### DIFF
--- a/idr/idr.py
+++ b/idr/idr.py
@@ -412,9 +412,9 @@ def write_results_to_file(merged_peaks, output_file,
     # write out the result
     idr.log("Writing results to file", "VERBOSE");
     
-    if localIDRs == None or IDRs == None:
-        assert IDRs == None
-        assert localIDRs == None
+    if localIDRs is None or IDRs is None:
+        assert IDRs is None
+        assert localIDRs is None
         localIDRs = numpy.ones(len(merged_peaks))
         IDRs = numpy.ones(len(merged_peaks))
 


### PR DESCRIPTION
This change avoids raising the following FutureWarning in Python 3.4:

```
idr.py:415: FutureWarning: comparison to `None` will result in an elementwise object comparison in the future.
    if localIDRs == None or IDRs == None:
```