### PR TITLE
fix bug (when summit in merged peaks is None)

### DIFF
--- a/idr/idr.py
+++ b/idr/idr.py
@@ -13,6 +13,7 @@ from itertools import chain
 
 def mean(items):
     items = list(items)
+    if len(items)==0: return 0.0
     return sum(items)/float(len(items))
 
 import idr
@@ -349,7 +350,7 @@ def build_idr_output_line_with_bed6(
             rv.append( "%.5f" % signal )
             if output_file_type == 'narrowPeak':
                 rv.append( "%i" % int(
-                    mean(x.summit-x.start for x in m_pk.pks[key])
+                    mean(x.summit-x.start for x in m_pk.pks[key] if x.summit != None)
                 ))
                                        
             


### PR DESCRIPTION
I got errors when running pipelines for some samples from Butcher's lab. This PR is a fix for it.
```
                Traceback (most recent call last):
                  File "/software/miniconda3/envs/bds_atac_py3/bin/idr", line 4, in <module>
                    __import__('pkg_resources').run_script('idr==2.0.3', 'idr')
                  File "/software/miniconda3/envs/bds_atac_py3/lib/python3.5/site-packages/setuptools-27.2.0-py3.5.egg/pkg_resources/__init__.py", line 744, in run_script
                  File "/software/miniconda3/envs/bds_atac_py3/lib/python3.5/site-packages/setuptools-27.2.0-py3.5.egg/pkg_resources/__init__.py", line 1499, in run_script
                  File "/software/miniconda3/envs/bds_atac_py3/lib/python3.5/site-packages/idr-2.0.3-py3.5-linux-x86_64.egg/EGG-INFO/scripts/idr", line 10, in <module>
                    idr.idr.main()
                  File "/software/miniconda3/envs/bds_atac_py3/lib/python3.5/site-packages/idr-2.0.3-py3.5-linux-x86_64.egg/idr/idr.py", line 899, in main
                    useBackwardsCompatibleOutput=args.use_old_output_format)
                  File "/software/miniconda3/envs/bds_atac_py3/lib/python3.5/site-packages/idr-2.0.3-py3.5-linux-x86_64.egg/idr/idr.py", line 486, in write_results_to_file
                    merged_peak, IDR, localIDR, output_file_type, signal_type)
                  File "/software/miniconda3/envs/bds_atac_py3/lib/python3.5/site-packages/idr-2.0.3-py3.5-linux-x86_64.egg/idr/idr.py", line 352, in build_idr_output_line_with_bed6
                    mean(x.summit-x.start for x in m_pk.pks[key])
                  File "/software/miniconda3/envs/bds_atac_py3/lib/python3.5/site-packages/idr-2.0.3-py3.5-linux-x86_64.egg/idr/idr.py", line 15, in mean
                    items = list(items)
                  File "/software/miniconda3/envs/bds_atac_py3/lib/python3.5/site-packages/idr-2.0.3-py3.5-linux-x86_64.egg/idr/idr.py", line 352, in <genexpr>
                    mean(x.summit-x.start for x in m_pk.pks[key])
                TypeError: unsupported operand type(s) for -: 'NoneType' and 'int'
```